### PR TITLE
fix to show image on display food bag

### DIFF
--- a/components/DisplayFoodBag.jsx
+++ b/components/DisplayFoodBag.jsx
@@ -1,26 +1,20 @@
-import React, { useEffect, useState } from 'react'
-import { Image, StyleSheet, Text, Switch, SafeAreaView } from 'react-native'
+import React, { useState } from 'react'
+import { StyleSheet, Text, Switch, SafeAreaView } from 'react-native'
 import { Card } from 'react-native-elements'
 import FoodBagService from '../modules/FoodBagService'
-import DonorService from '../modules/DonorService'
 
 const DisplayFoodBag = ({ foodbag, id }) => {
   const [switchValue, setSwitchValue] = useState(false)
 
-  useEffect(() => {
-    DonorService.show(id)
-  }, [])
-
   const toggleSwitch = async foodbag => {
     setSwitchValue(true)
-    debugger
     let response = await FoodBagService.update(foodbag)
   }
 
   return (
     <SafeAreaView style={{ flex: 1 }}>
       <Card>
-        <Image style={styles.storeImage} src={foodbag.donor.image} />
+        <Card.Image style={styles.storeImage} source={{uri: foodbag.donor.image}} />
         <Card.Title style={styles.coName}>
           {foodbag.donor.company_name}
         </Card.Title>
@@ -44,7 +38,7 @@ const DisplayFoodBag = ({ foodbag, id }) => {
         )}
 
         <Text style={styles.toggle}>
-          {switchValue && 'You foodbag is reserved'}
+          {switchValue && 'Your foodbag is reserved'}
         </Text>
       </Card>
     </SafeAreaView>

--- a/modules/DonorService.js
+++ b/modules/DonorService.js
@@ -11,7 +11,6 @@ const DonorService = {
       let response = await axios.get(API_URL + `/user/${id}`, {
         headers: headers,
       })
-      debugger
       store.dispatch({
         type: 'SET_DONOR_DATA',
         payload: response.data.donor,


### PR DESCRIPTION
### User Story
```
As a recipient
In order to be able to see a list of available foodbags
I would like to see a list of stores with company name, adress and a the company logo
```
## Changes proposed in this pull request:
* Recipient can see a list of donors information plus logo
* 
## Screenshots (Client)
![Screenshot from 2021-02-05 23-58-27](https://user-images.githubusercontent.com/72553754/107098422-757f3080-680f-11eb-83bc-5545ace87018.png)


